### PR TITLE
fix(dto): remove conflicting constructor annotations from UserRespons…

### DIFF
--- a/src/main/java/edu/eci/cvds/users/dto/UserResponseDTO.java
+++ b/src/main/java/edu/eci/cvds/users/dto/UserResponseDTO.java
@@ -12,6 +12,5 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
 public class UserResponseDTO extends BaseUserDTO {
 }


### PR DESCRIPTION
Removed @AllArgsConstructor from UserResponseDTO because Lombok cannot generate constructors for inherited fields from BaseUserDTO, causing compilation failure.
