### PR TITLE
feat(service): implement service & repository layers for user management

### DIFF
--- a/src/main/java/edu/eci/cvds/users/dto/BaseUserDTO.java
+++ b/src/main/java/edu/eci/cvds/users/dto/BaseUserDTO.java
@@ -25,4 +25,46 @@ public class BaseUserDTO {
 
     @NotBlank
     private String role;
+
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getIdType() {
+        return idType;
+    }
+    public void setIdType(String idType) {
+        this.idType = idType;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
+    }
+
+    public Integer getPhone() {
+        return phone;
+    }
+    public void setPhone(Integer phone) {
+        this.phone = phone;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getRole() {
+        return role;
+    }
+    public void setRole(String role) {
+        this.role = role;
+    }
 }

--- a/src/main/java/edu/eci/cvds/users/dto/StudentRequestDTO.java
+++ b/src/main/java/edu/eci/cvds/users/dto/StudentRequestDTO.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 
 /**
  * Payload DTO for creating or updating a Student.
- * Hereda de UserRequestDTO (y por tanto de BaseUserDTO) todos los campos comunes.
+ * Hereda de UserRequestDTO todos los campos comunes.
  */
 @Getter @Setter
 public class StudentRequestDTO extends UserRequestDTO {
@@ -27,4 +27,39 @@ public class StudentRequestDTO extends UserRequestDTO {
 
     @NotBlank
     private String emergencyContactId;
+
+    public String getStudentCode() {
+        return studentCode;
+    }
+    public void setStudentCode(String studentCode) {
+        this.studentCode = studentCode;
+    }
+
+    public String getProgram() {
+        return program;
+    }
+    public void setProgram(String program) {
+        this.program = program;
+    }
+
+    public LocalDate getBirthDate() {
+        return birthDate;
+    }
+    public void setBirthDate(LocalDate birthDate) {
+        this.birthDate = birthDate;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getEmergencyContactId() {
+        return emergencyContactId;
+    }
+    public void setEmergencyContactId(String emergencyContactId) {
+        this.emergencyContactId = emergencyContactId;
+    }
 }

--- a/src/main/java/edu/eci/cvds/users/dto/UserResponseDTO.java
+++ b/src/main/java/edu/eci/cvds/users/dto/UserResponseDTO.java
@@ -9,8 +9,8 @@ import lombok.Setter;
  * Response DTO returned by user endpoints.
  * Extiende BaseUserDTO para exponer los mismos campos.
  */
-@Getter
-@Setter
-@NoArgsConstructor
+
 public class UserResponseDTO extends BaseUserDTO {
+
+    public UserResponseDTO() {}
 }

--- a/src/main/java/edu/eci/cvds/users/repository/EmergencyContactRepository.java
+++ b/src/main/java/edu/eci/cvds/users/repository/EmergencyContactRepository.java
@@ -1,0 +1,7 @@
+package edu.eci.cvds.users.repository;
+
+import edu.eci.cvds.users.model.EmergencyContact;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmergencyContactRepository extends JpaRepository<EmergencyContact, String> {
+}

--- a/src/main/java/edu/eci/cvds/users/repository/StaffRepository.java
+++ b/src/main/java/edu/eci/cvds/users/repository/StaffRepository.java
@@ -1,0 +1,7 @@
+package edu.eci.cvds.users.repository;
+
+import edu.eci.cvds.users.model.Staff;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StaffRepository extends JpaRepository <Staff, String>{
+}

--- a/src/main/java/edu/eci/cvds/users/repository/StudentRepository.java
+++ b/src/main/java/edu/eci/cvds/users/repository/StudentRepository.java
@@ -1,0 +1,7 @@
+package edu.eci.cvds.users.repository;
+
+import edu.eci.cvds.users.model.Student;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudentRepository extends JpaRepository<Student, String> {
+}

--- a/src/main/java/edu/eci/cvds/users/service/UserService.java
+++ b/src/main/java/edu/eci/cvds/users/service/UserService.java
@@ -1,0 +1,16 @@
+package edu.eci.cvds.users.service;
+
+import edu.eci.cvds.users.dto.StudentRequestDTO;
+import edu.eci.cvds.users.dto.UserRequestDTO;
+import edu.eci.cvds.users.dto.UserResponseDTO;
+
+public interface UserService {
+    // 1) Add student
+    UserResponseDTO createStudent(StudentRequestDTO dto);
+
+    // 2) Add administrator (or other staff rol)
+    UserResponseDTO createUser(UserRequestDTO dto);
+
+    // 3) Get user by ID
+    UserResponseDTO getUserById(String id);
+}

--- a/src/main/java/edu/eci/cvds/users/service/UserServiceImpl.java
+++ b/src/main/java/edu/eci/cvds/users/service/UserServiceImpl.java
@@ -1,0 +1,118 @@
+package edu.eci.cvds.users.service;
+
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import edu.eci.cvds.users.dto.*;
+import edu.eci.cvds.users.model.*;
+import edu.eci.cvds.users.repository.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional
+public class UserServiceImpl implements UserService {
+    @Autowired
+    private StudentRepository studentRepo;
+
+    @Autowired
+    private StaffRepository staffRepo;
+
+    @Autowired
+    private UserRepository userRepo;
+
+    @Autowired
+    private EmergencyContactRepository contactRepo;
+
+    @Override
+    public UserResponseDTO createStudent(StudentRequestDTO dto) {
+        // 1) Busca el EmergencyContact
+        EmergencyContact ec = contactRepo.findById(dto.getEmergencyContactId())
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Emergency contact not found: " + dto.getEmergencyContactId()));
+
+
+        // 2) Crea la entidad Student
+        Student student = new Student(
+                dto.getId(),
+                dto.getIdType(),
+                dto.getFullName(),
+                dto.getPhone(),
+                dto.getEmail(),
+                Role.valueOf(dto.getRole()),
+                dto.getStudentCode(),
+                dto.getProgram(),
+                dto.getBirthDate(),
+                ec,
+                dto.getAddress()
+        );
+        studentRepo.save(student);
+
+        // 3) Mapea y devuelve con setters
+        UserResponseDTO response = new UserResponseDTO();
+        response.setId        (student.getId());
+        response.setIdType    (student.getIdType());
+        response.setFullName  (student.getFullName());
+        response.setPhone     (student.getPhone());
+        response.setEmail     (student.getEmail());
+        response.setRole      (student.getRole().name());
+        return response;
+    }
+
+    @Override
+    public UserResponseDTO createUser(UserRequestDTO dto) {
+        Staff staff = new Staff(
+                dto.getId(),
+                dto.getIdType(),
+                dto.getFullName(),
+                dto.getPhone(),
+                dto.getEmail(),
+                Role.valueOf(dto.getRole()),
+                null,             // specialty (solo si aplica)
+                List.of()         // schedule vacío inicialmente
+        );
+
+        // Mapear a DTO de respuesta
+        UserResponseDTO response = new UserResponseDTO();
+        response.setId        (staff.getId());
+        response.setIdType    (staff.getIdType());
+        response.setFullName  (staff.getFullName());
+        response.setPhone     (staff.getPhone());
+        response.setEmail     (staff.getEmail());
+        response.setRole      (staff.getRole().name());
+        return response;
+    }
+
+    @Override
+    public UserResponseDTO getUserById(String id) {
+        // Intentar encontrar al user como Student
+        Optional<Student> optStudent = studentRepo.findById(id);
+        if (optStudent.isPresent()) {
+            Student s = optStudent.get();
+            UserResponseDTO response = new UserResponseDTO();
+            response.setId        (s.getId());
+            response.setIdType    (s.getIdType());
+            response.setFullName  (s.getFullName());
+            response.setPhone     (s.getPhone());
+            response.setEmail     (s.getEmail());
+            response.setRole      (s.getRole().name());
+            return response;
+        }
+
+        // Si no es Student, intentar como Staff
+        Staff staff = staffRepo.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + id));
+
+        UserResponseDTO response = new UserResponseDTO();
+        response.setId        (staff.getId());
+        response.setIdType    (staff.getIdType());
+        response.setFullName  (staff.getFullName());
+        response.setPhone     (staff.getPhone());
+        response.setEmail     (staff.getEmail());
+        response.setRole      (staff.getRole().name());
+        return response;
+    }
+}


### PR DESCRIPTION
- Add StudentRepository, StaffRepository and EmergencyContactRepository extending JpaRepository  
- Update UserRepository for generic User operations  
- Define UserService interface with methods: createStudent, createUser, getUserById  
- Implement UserServiceImpl with transactional logic:  
  • createStudent looks up EmergencyContact, saves Student, maps to UserResponseDTO  
  • createUser saves Staff and maps to UserResponseDTO  
  • getUserById retrieves either Student or Staff and maps to UserResponseDTO  
- Wire repositories via @Autowired and annotate service with @Service and @Transactional