### PR TITLE
feat: integrate Swagger UI for API documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,13 @@
             <version>3.0.2</version>
         </dependency>
 
+        <!-- Swagger -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.7</version>
+        </dependency>
+
         <!-- JUnit 5 -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
feat: integrate Swagger UI for API documentation

- Added springdoc-openapi dependency to pom.xml
- Configured Swagger UI to expose API docs at /swagger-ui/index.html
- Verified accessibility of OpenAPI JSON at /v3/api-docs
- Confirmed context-path handling and basic UI availability